### PR TITLE
Feat gene id mapping

### DIFF
--- a/functional_integration/map_hg19_to_hg38.R
+++ b/functional_integration/map_hg19_to_hg38.R
@@ -78,4 +78,4 @@ hg19.unmapped <- hg19.unmapped %>%
 # Append the ids & names of the unmapped
 hg19to38map.df <- rbind(hg19to38map.df, hg19.unmapped)
 
-fwrite(hg19to38map.df, sep = "\t", paste0(genomes.dir,"hg19_to_hg38_map.tsv"))
+fwrite(hg19to38map.df, sep = "\t", paste0(work.dir,"hg19_to_hg38_map.tsv"))


### PR DESCRIPTION
 #7  directly matched hg19 ensembl gene IDs to hg38. where this was not possible, matched by gene name. exports tsv that maps old IDs to new IDs.  #of ~14k genes, ~200 could not be assigned an ID. 